### PR TITLE
Bugfix: Handle empty result from querying event logs in EType identification scripts.

### DIFF
--- a/Get-KerbEncryptionUsage.ps1
+++ b/Get-KerbEncryptionUsage.ps1
@@ -206,7 +206,10 @@ if ("AllKdcs" -eq $SearchScope) {
         $KDCName = $_.HostName
         try {
             [Array]$r = $(Get-KdcEventLog -KDCName $KDCName -Query $script:XPathQuery)
-            $Events.AddRange($r)
+
+            if ($null -ne $r -and 0 -ne $r.Count) {
+                $Events.AddRange($r)
+            }
         }
         catch {
             Write-Error "Failed to get event logs from $KDCName with result: $_"
@@ -214,8 +217,15 @@ if ("AllKdcs" -eq $SearchScope) {
     }
 }
 else {
-    [Array]$r = $(Get-KdcEventLog -Query $script:XPathQuery)
-    $Events.AddRange($r)
+    try {
+        [Array]$r = $(Get-KdcEventLog -Query $script:XPathQuery)
+
+        if ($null -ne $r -and 0 -ne $r.Count) {
+            $Events.AddRange($r)
+        }
+    } catch {
+        Write-Error "Failed to get event logs from $KDCName with result: $_"
+    }
 }
 
 # Validate we are working with the correct version

--- a/List-AccountKeys.ps1
+++ b/List-AccountKeys.ps1
@@ -201,14 +201,20 @@ if ("None" -ne $NotContainsKeyType) {
 $accounts = [System.Collections.ArrayList]::new()
 if ("This" -eq $SearchScope) {
     [Array]$r = $(Get-AccountsFromKDC -Query $script:XPathQuery)
-    $accounts.AddRange($r)
+
+    if ($null -ne $r -and 0 -ne $r.Count) {
+        $accounts.AddRange($r)
+    }
 }
 else {
     Get-ADDomainController -Service KDC -Discover | ForEach-Object {
         $KDCName = $_.HostName
         try {
             [Array]$r = $(Get-AccountsFromKDC -KDCName $KDCName -Query $script:XPathQuery)
-            $accounts.AddRange($r)
+
+            if ($null -ne $r -and 0 -ne $r.Count) {
+                $accounts.AddRange($r)
+            }
         }
         catch {
             Write-Error "Failed to get event logs from $KDCName with result: $_"


### PR DESCRIPTION
Addresses #9 

The return could be 0 / `null` if we do not find any of the relevant events in the event log. We now account for this before adding the result to the containing array list.


