### PR TITLE
[GitHub] Security: Limit scope of permissions for pester workflow

### DIFF
--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -1,4 +1,6 @@
 name: Run Pester Tests
+permissions:
+  contents: read
 on: push
 
 jobs:


### PR DESCRIPTION
## Why is this change being made?

Code scanning alerts created [Workflow does not contain permissions](https://github.com/microsoft/Kerberos-Crypto/security/code-scanning/1)

## What changed?

Add permission scoping to pester workflow.

## How was the change tested?

GitHub action.

## Related Issues

- [Workflow does not contain permissions](https://github.com/microsoft/Kerberos-Crypto/security/code-scanning/1)
