### PR TITLE
Bug Fix: Handle record id greater than [int]::MaxValue

### DIFF
--- a/scripts/Get-KerbEncryptionUsage.ps1
+++ b/scripts/Get-KerbEncryptionUsage.ps1
@@ -70,7 +70,7 @@ enum RequestType {
 }
 
 class KerbRequest {
-    hidden [int]$RecordId
+    hidden [long]$RecordId
     [string]$MachineName
     [DateTime]$Time
     [string]$Requestor
@@ -80,7 +80,7 @@ class KerbRequest {
     [EncryptionType]$Ticket
     [EncryptionType]$SessionKey
 
-    KerbRequest([int]$id, [string]$m, [datetime]$tc, [string]$r, [string]$s, [string]$t, [RequestType]$rt, [EncryptionType]$te, [EncryptionType]$se) {
+    KerbRequest([long]$id, [string]$m, [datetime]$tc, [string]$r, [string]$s, [string]$t, [RequestType]$rt, [EncryptionType]$te, [EncryptionType]$se) {
         $this.RecordId = $id
         $this.MachineName = $m
         $this.Time = $tc

--- a/scripts/List-AccountKeys.ps1
+++ b/scripts/List-AccountKeys.ps1
@@ -50,14 +50,14 @@ enum AccountType {
 }
 
 class Account {
-    hidden [int]$RecordId
+    hidden [long]$RecordId
     [string]$MachineName
     [datetime]$Time
     [string]$Name
     [AccountType]$Type
     [string]$Keys
 
-    Account([int]$id, [string]$m, [datetime]$tc, [string]$name, [AccountType]$ct, [string]$ckeys) {
+    Account([long]$id, [string]$m, [datetime]$tc, [string]$name, [AccountType]$ct, [string]$ckeys) {
         $this.RecordId = $id
         $this.MachineName = $m
         $this.Time = $tc


### PR DESCRIPTION
## Why is this change being made?

Large event logs can easily have a record id that is greater than `[int]::MaxValue` (2147483647) leading an integer overflow exception.

## What changed?

Change `$RecordId` from `[int]` to `[long]`.

## How was the change tested?

N/A

## Related Issues

#19 
