### PR TITLE
Fix account key filtering pipeline skips

### DIFF
--- a/scripts/ETypeDetection.Tests.ps1
+++ b/scripts/ETypeDetection.Tests.ps1
@@ -172,6 +172,18 @@ BeforeAll {
         return $script:KDCs
     }
 
+    function Copy-TestEventWithAccountKeys {
+        param(
+            [object]$Event,
+            [string]$AccountKeys
+        )
+
+        $copy = $Event.PSObject.Copy()
+        $copy.Properties = @($Event.Properties | ForEach-Object { @{ Value = $_.Value } })
+        $copy.Properties[16].Value = $AccountKeys
+        return $copy
+    }
+
 }
 
 
@@ -356,6 +368,22 @@ Describe 'List-AccountKeys.ps1' {
 
             $results = List-AccountKeys -NotContainsKeyType "AES-SHA1"
             $results.Count | Should -Be 0
+        }
+
+        It 'should keep filtering after the first record is excluded' {
+            $rc4OnlyEvent = Copy-TestEventWithAccountKeys $script:AES_4769_EVENT "RC4"
+
+            Mock Get-WinEvent {
+                return $rc4OnlyEvent, $script:AES_4769_EVENT
+            }
+
+            $containsResults = List-AccountKeys -ContainsKeyType "AES-SHA1"
+            $containsResults.Count | Should -Be 1
+            $containsResults[0].Keys | Should -Match "AES"
+
+            $notContainsResults = List-AccountKeys -NotContainsKeyType "AES-SHA1"
+            $notContainsResults.Count | Should -Be 1
+            $notContainsResults[0].Keys | Should -Be "RC4"
         }
     }
 

--- a/scripts/List-AccountKeys.ps1
+++ b/scripts/List-AccountKeys.ps1
@@ -180,28 +180,31 @@ function List-AccountKeys {
         [string]$SearchScope = "This"
     )
 
+    $KeyFilter = $null
+    $NotKeyFilter = $null
+
     if ("All" -ne $ContainsKeyType) {
         # translate AES-SHA1 into either
         if ("AES-SHA1" -eq $ContainsKeyType) {
-            $script:KeyFilter = $script:AES_SHA1_FILTER
+            $KeyFilter = $script:AES_SHA1_FILTER
         }
         elseif ("DES" -eq $ContainsKeyType) {
-            $script:KeyFilter = "DES"
+            $KeyFilter = "DES"
         }
         else {
-            $script:KeyFilter = $ContainsKeyType
+            $KeyFilter = $ContainsKeyType
         }
     }
 
     if ("None" -ne $NotContainsKeyType) {
         if ("AES-SHA1" -eq $NotContainsKeyType) {
-            $script:NotKeyFilter = $script:AES_SHA1_FILTER
+            $NotKeyFilter = $script:AES_SHA1_FILTER
         }
-        elseif ("DES" -eq $ContainsKeyType) {
-            $script:NotKeyFilter = "DES"
+        elseif ("DES" -eq $NotContainsKeyType) {
+            $NotKeyFilter = "DES"
         }
         else {
-            $script:NotKeyFilter = $NotContainsKeyType
+            $NotKeyFilter = $NotContainsKeyType
         }
     }
 
@@ -242,15 +245,15 @@ Please install the most recent Windows Updates available for this machine and at
     $accounts | ForEach-Object {
         $KDC = $_.MachineName
         [string]$keys = $_.Properties[16].Value
-        if (-not [string]::IsNullOrEmpty($script:NotKeyFilter)) {
-            if ($keys.Contains($script:NotKeyFilter)) {
-                continue
+        if (-not [string]::IsNullOrEmpty($NotKeyFilter)) {
+            if ($keys.Contains($NotKeyFilter)) {
+                return
             }
         }
 
-        if (-not [string]::IsNullOrEmpty($script:KeyFilter)) {
-            if (-not $keys.Contains($script:KeyFilter)) {
-                continue
+        if (-not [string]::IsNullOrEmpty($KeyFilter)) {
+            if (-not $keys.Contains($KeyFilter)) {
+                return
             }
         }
 


### PR DESCRIPTION
## Summary
- keep `List-AccountKeys` filter state local to each invocation
- use `return` inside the `ForEach-Object` pipeline so filtered accounts are skipped without truncating later results
- fix the `-NotContainsKeyType DES` branch to check the right parameter

Fixes #27.

## Testing
- mocked `Get-AccountsFromKDC` event results and verified `-ContainsKeyType AES-SHA1`, `-NotContainsKeyType AES-SHA1`, and `-NotContainsKeyType DES`
- `git diff --check`